### PR TITLE
Restore training icons depending on counters

### DIFF
--- a/src/helpers/piaf.ts
+++ b/src/helpers/piaf.ts
@@ -1,7 +1,18 @@
-import { PIAF } from "src/types/model"
+import { PIAF, RoleId } from "src/types/model"
 
-export const getPiafRole = ({ role }: PIAF) => {
-  return role?.roleUniqueId
+export const getPiafRole = ({ role, piaffeur }: PIAF) => {
+  if (!role) {
+    return null
+  }
+  if (piaffeur) {
+    if (role.roleUniqueId === RoleId.GrandHibou && !piaffeur.nbPiafGH) {
+      return RoleId.GrandHibou_Formation
+    }
+    if (role.roleUniqueId === RoleId.Caissier && !piaffeur.nbPiafCaisse) {
+      return RoleId.Caissier_Formation
+    }
+  }
+  return role.roleUniqueId
 }
 
 export const isTaken = (piaf: PIAF) => {


### PR DESCRIPTION
Once the `nbPiafGH` and `nbPiafCaisse` are back up and running, use them to show a PIAF as "training" when they are at zero.

This reverts commit 417456eacb5ccd441a1fe20dc32ffbeba3b1e086.

Note that for now, the API is missing the  roles `GHF` and `CAF`, defined here:
https://github.com/lachouettecoop/planning/blob/main/src/types/model.ts#L3-L17

As you can see: https://adminchouettos.lachouettecoop.fr/api/graphql?query=query%20%7B%0A%20%20roles%20%7B%0A%20%20%20%20libelle%0A%20%20%20%20id%0A%20%20%20%20roleUniqueId%0A%20%20%7D%0A%7D

So the backend team needs to update their `roles` table first, to be in sync with this data.